### PR TITLE
tiny bug fix 

### DIFF
--- a/plugins/plugin-radius/src/api/api.ts
+++ b/plugins/plugin-radius/src/api/api.ts
@@ -108,14 +108,15 @@ export class RadiusApiImpl implements RadiusApi {
       const groupResources = await this.makeRequest<
         ResourceList<Record<string, never>>
       >(cluster, path);
-      for (const resource of groupResources.value) {
-        // Deployments show up in tracked resources, but the RP may not hold onto them.
-        // There's limited value here so skip them for now.
-        if (resource.type === 'Microsoft.Resources/deployments') {
-          continue;
+      if (groupResources.value) {
+        for (const resource of groupResources.value) {
+          // Deployments show up in tracked resources, but the RP may not hold onto them.
+          // There's limited value here so skip them for now.
+          if (resource.type === 'Microsoft.Resources/deployments') {
+            continue;
+          }
+          resources.push(await this.getResourceById<T>({ id: resource.id }));
         }
-
-        resources.push(await this.getResourceById<T>({ id: resource.id }));
       }
     }
     return { value: resources };


### PR DESCRIPTION
add a check before accessing value to avoid error 
```
2024-01-09T18:46:01.861Z catalog warn Unable to read radius, TypeError: response.value is not iterable type=plugin entity=location:default/generated-722c76a4c07655e71b171284aa3705f34ba0c1ca
```