### PR TITLE
Remove serviceAccountToken and add deploy file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ Key features of the Radius Dashboard currently include:
    ```bash
    kubectl apply -f https://raw.githubusercontent.com/radius-project/dashboard/main/deploy/dashboard.yaml
    ```
+
 1. Once the manifest is applied and the resources are created, port-forward the dashboard service to your local machine:
 
    ```bash
    kubectl port-forward --namespace=radius-system svc/dashboard 3000:80
    ```
+
 1. Access the dashboard at [http://localhost:3000](http://localhost:3000)
 
 ## Getting help

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Radius Dashboard is the frontend experience for [Radius](https://github.com/radius-project/radius), a cloud-native application platform that enables developers and the platform engineers that support them to collaborate on delivering and managing cloud-native applications that follow organizational best practices for cost, operations and security, by default. Radius is an open-source project that supports deploying applications across private cloud, Microsoft Azure, and Amazon Web Services, with more cloud providers to come.
 
-> NOTE: Radius Dashboard is currently in a prototype stage and thus is not yet packaged into Radius and its releases, though we are planning to add it to the Radius installation soon. The best way to use Radius Dashboard right now is to clone the repo and run it locally, see the [contribution guide](./CONTRIBUTING.md) for instructions on how to build and run the code.
+> NOTE: Radius Dashboard is currently in a prototype stage and thus is not yet packaged into Radius and its releases, though we are planning to add it to the Radius installation soon. The best way to use Radius Dashboard right now is to [manually install it in your cluster](#kubernetes-installation), or clone the repo and run it locally. See the [contribution guide](./CONTRIBUTING.md) for instructions on how to build and run the code.
 
 The Radius Dashboard is built on [Backstage](https://backstage.io/), an open-source platform for building developer portals that provides a rich set of components to accelerate UI development. The Radius Dashboard is a skinned deployment of Backstage that includes a set of plugins that provide the Radius experience. The components that make up the dashboard are built with extensibility in mind so that they can be used in other contexts beyond Backstage in the future.
 
@@ -11,6 +11,24 @@ Key features of the Radius Dashboard currently include:
 - _Application graph visualization_: A visualization of the application graph that shows how resources within an application are connected to each other and the underlying infrastructure.
 - _Resource overview and details_: Detailed information about resources within Radius, including applications, environments, and infrastructure.
 - _Recipes directory_: A listing of all the Radius Recipes available to the user for a given environment.
+
+## Kubernetes installation
+
+> NOTE: The Radius Dashboard is currently in a prototype stage and is distributed separately from the main Radius project. The best way to use Radius Dashboard right now is to manually install it in your cluster:
+
+1. Make sure you have a Kubernetes cluster running and `kubectl` installed and configured to point to your cluster.
+1. Ensure you have Radius installed and running in your cluster. If you don't have Radius installed, you can follow the [Radius installation guide](https://docs.radapp.io/installation/)
+1. Apply the [Radius Dashboard manifest](./deploy/dashboard.yaml) to your cluster:
+
+   ```bash
+   kubectl apply -f https://raw.githubusercontent.com/radius-project/dashboard/main/deploy/dashboard.yaml
+   ```
+1. Once the manifest is applied and the resources are created, port-forward the dashboard service to your local machine:
+
+   ```bash
+   kubectl port-forward --namespace=radius-system svc/dashboard 3000:80
+   ```
+1. Access the dashboard at [http://localhost:3000](http://localhost:3000)
 
 ## Getting help
 

--- a/app-config.dashboard.yaml
+++ b/app-config.dashboard.yaml
@@ -21,6 +21,8 @@ kubernetes:
     - type: config
       clusters:
         - name: self
+          # The URL to the in-cluster Kubernetes API server.
+          # Backstage docs state it should be ignored when in-cluster, but it appears to be used.
           url: https://kubernetes.default.svc.cluster.local
           authProvider: serviceAccount
           skipTLSVerify: true

--- a/app-config.dashboard.yaml
+++ b/app-config.dashboard.yaml
@@ -21,7 +21,7 @@ kubernetes:
     - type: config
       clusters:
         - name: self
-          url: https://kubernetes
+          url: https://kubernetes.default.svc.cluster.local
           authProvider: serviceAccount
           skipTLSVerify: true
           skipMetricsLookup: true

--- a/app-config.dashboard.yaml
+++ b/app-config.dashboard.yaml
@@ -20,12 +20,11 @@ kubernetes:
   clusterLocatorMethods:
     - type: config
       clusters:
-        - name: minikube
+        - name: self
           url: https://kubernetes
           authProvider: serviceAccount
           skipTLSVerify: true
           skipMetricsLookup: true
-          serviceAccountToken: 'asdf'
 catalog:
   # Overrides the default list locations from app-config.yaml as these contain example data.
   # See https://backstage.io/docs/features/software-catalog/#adding-components-to-the-catalog for more details

--- a/deploy/dashboard.yaml
+++ b/deploy/dashboard.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dashboard
+  namespace: radius-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dashboard
+  template:
+    metadata:
+      labels:
+        app: dashboard
+    spec:
+      serviceAccountName: dashboard-account
+      containers:
+        - name: dashboard
+          image: ghcr.io/aaroncrawfis/dashboard:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 7007
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dashboard
+  namespace: radius-system
+spec:
+  selector:
+    app: dashboard
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dashboard-account
+  namespace: radius-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dashboard-role
+  namespace: radius-system
+rules:
+  - apiGroups: ["", "api.ucp.dev"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dashboard-role-binding
+  namespace: radius-system
+subjects:
+  - kind: ServiceAccount
+    name: dashboard-account
+    namespace: radius-system
+roleRef:
+  kind: ClusterRole
+  name: dashboard-role
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/dashboard.yaml
+++ b/deploy/dashboard.yaml
@@ -48,9 +48,9 @@ metadata:
   name: dashboard-role
   namespace: radius-system
 rules:
-  - apiGroups: ["", "api.ucp.dev"]
-    resources: ["*"]
-    verbs: ["*"]
+  - apiGroups: ['', 'api.ucp.dev']
+    resources: ['*']
+    verbs: ['*']
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This PR removes the config for Kubernetes serviceAccountToken, because it's expected that the service is running in cluster.

See https://backstage.io/docs/features/kubernetes/configuration/#clustersserviceaccounttoken-optional for more info on in-cluster setups.