### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "devcontainers"
+    directory: "/.devcontainer"
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,26 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "npm"
-    directory: "/"
+      interval: 'weekly'
+    groups:
+      all:
+        patterns:
+          - '*'
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "devcontainers"
-    directory: "/.devcontainer"
+      interval: 'weekly'
+    groups:
+      all:
+        patterns:
+          - '*'
+  - package-ecosystem: 'devcontainers'
+    directory: '/.devcontainer'
     schedule:
       interval: weekly
+    groups:
+      all:
+        patterns:
+          - '*'


### PR DESCRIPTION
This PR adds the configuration for dependabot version updates comprising the folowing package ecosystems:

- yarn/node
- GitHub Actions
- devcontainer features 

The dependabot is executed on a weekly schedule.

See also: https://github.com/radius-project/radius/pull/7307