### PR TITLE
update gh to ado sync workflow to use service principals

### DIFF
--- a/.github/workflows/devops-boards.yaml
+++ b/.github/workflows/devops-boards.yaml
@@ -13,15 +13,45 @@ jobs:
   alert:
     runs-on: ubuntu-latest
     steps:
-      - uses: danhellem/github-actions-issue-to-work-item@v2.2
+      # Auth using Azure Service Principals was added as a part of v2.3
+      # reference: https://github.com/danhellem/github-actions-issue-to-work-item/pull/143
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_SP_DEVOPS_SYNC_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_SP_DEVOPS_SYNC_TENANT_ID }}
+          allow-no-subscriptions: true
+      - name: Get Azure DevOps token
+        id: get_ado_token
+        run:
+          # The resource ID for Azure DevOps is always 499b84ac-1321-427f-aa17-267ca6975798
+          # https://learn.microsoft.com/azure/devops/integrate/get-started/authentication/service-principal-managed-identity
+          accessToken=$(az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query "accessToken" --output tsv)
+          echo "ADO_TOKEN=$accessToken" >> $GITHUB_ENV
+      - name: Sync issue to Azure DevOps
+        uses: danhellem/github-actions-issue-to-work-item@v2.3
         env:
-          ado_token: '${{ secrets.ADO_AOCTO_BOT_TOKEN }}'
-          github_token: '${{ secrets.GH_RAD_CI_BOT_PAT }}'
-          ado_organization: 'azure-octo'
-          ado_project: 'Incubations'
+          ado_token: ${{ env.ADO_TOKEN }}
+          github_token: "${{ secrets.GH_RAD_CI_BOT_PAT }}"
+          ado_organization: "azure-octo"
+          ado_project: "Incubations"
           ado_area_path: "Incubations\\Radius"
           ado_iteration_path: "Incubations\\Radius"
-          ado_wit: 'GitHub Issue'
-          ado_new_state: 'New'
-          ado_active_state: 'Active'
-          ado_close_state: 'Closed'
+          ado_new_state: "New"
+          ado_active_state: "Active"
+          ado_close_state: "Closed"
+          ado_wit: "GitHub Issue"
+
+      ### REMOVE THIS ONCE THE ACTION IS WORKING ###
+      # - uses: danhellem/github-actions-issue-to-work-item@v2.2
+      #   env:
+      #     ado_token: '${{ secrets.ADO_AOCTO_BOT_TOKEN }}'
+      #     github_token: '${{ secrets.GH_RAD_CI_BOT_PAT }}'
+      #     ado_organization: 'azure-octo'
+      #     ado_project: 'Incubations'
+      #     ado_area_path: "Incubations\\Radius"
+      #     ado_iteration_path: "Incubations\\Radius"
+      #     ado_wit: 'GitHub Issue'
+      #     ado_new_state: 'New'
+      #     ado_active_state: 'Active'
+      #     ado_close_state: 'Closed'

--- a/.github/workflows/devops-boards.yaml
+++ b/.github/workflows/devops-boards.yaml
@@ -41,17 +41,3 @@ jobs:
           ado_active_state: 'Active'
           ado_close_state: 'Closed'
           ado_wit: 'GitHub Issue'
-
-      ### REMOVE THIS ONCE THE ACTION IS WORKING ###
-      # - uses: danhellem/github-actions-issue-to-work-item@v2.2
-      #   env:
-      #     ado_token: '${{ secrets.ADO_AOCTO_BOT_TOKEN }}'
-      #     github_token: '${{ secrets.GH_RAD_CI_BOT_PAT }}'
-      #     ado_organization: 'azure-octo'
-      #     ado_project: 'Incubations'
-      #     ado_area_path: "Incubations\\Radius"
-      #     ado_iteration_path: "Incubations\\Radius"
-      #     ado_wit: 'GitHub Issue'
-      #     ado_new_state: 'New'
-      #     ado_active_state: 'Active'
-      #     ado_close_state: 'Closed'

--- a/.github/workflows/devops-boards.yaml
+++ b/.github/workflows/devops-boards.yaml
@@ -32,15 +32,15 @@ jobs:
         uses: danhellem/github-actions-issue-to-work-item@v2.3
         env:
           ado_token: ${{ env.ADO_TOKEN }}
-          github_token: "${{ secrets.GH_RAD_CI_BOT_PAT }}"
-          ado_organization: "azure-octo"
-          ado_project: "Incubations"
+          github_token: '${{ secrets.GH_RAD_CI_BOT_PAT }}'
+          ado_organization: 'azure-octo'
+          ado_project: 'Incubations'
           ado_area_path: "Incubations\\Radius"
           ado_iteration_path: "Incubations\\Radius"
-          ado_new_state: "New"
-          ado_active_state: "Active"
-          ado_close_state: "Closed"
-          ado_wit: "GitHub Issue"
+          ado_new_state: 'New'
+          ado_active_state: 'Active'
+          ado_close_state: 'Closed'
+          ado_wit: 'GitHub Issue'
 
       ### REMOVE THIS ONCE THE ACTION IS WORKING ###
       # - uses: danhellem/github-actions-issue-to-work-item@v2.2


### PR DESCRIPTION
As explained in https://github.com/radius-project/radius/issues/7402, we must switch to using Service Principals for auth when running the GH-ADO sync workflow.

Auth using Azure Service Principals was added as a part of v2.3 of the `danhellem/github-actions-issue-to-work-item` GitHub Actions workflow we use. Reference: https://github.com/danhellem/github-actions-issue-to-work-item/pull/143