### PR TITLE
fix permission issues on ADO boards sync github action

### DIFF
--- a/.github/workflows/devops-boards.yaml
+++ b/.github/workflows/devops-boards.yaml
@@ -4,10 +4,17 @@ on:
   issues:
     types:
       [opened, edited, deleted, closed, reopened, labeled, unlabeled, assigned]
+  issue_comment:
+    types: [created, edited, deleted]
 
 concurrency:
   group: issue-${{ github.event.issue.number }}
   cancel-in-progress: false
+
+# Extra permissions needed to login with Entra ID service principal via federated identity
+permissions:
+  id-token: write
+  issues: write
 
 jobs:
   alert:


### PR DESCRIPTION
This is an additional change to fix the issue in https://github.com/radius-project/dashboard/pull/67 where inadequate permissions were not provided for the workflow. 

See here for more details:
https://github.com/danhellem/github-actions-issue-to-work-item/tree/master?tab=readme-ov-file#entra-id-service-principal