### PR TITLE
Ado sync workflow update to exclude pull request comments

### DIFF
--- a/.github/workflows/devops-boards.yaml
+++ b/.github/workflows/devops-boards.yaml
@@ -18,7 +18,6 @@ permissions:
 
 jobs:
   ado:
-    if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     environment:
       name: issues

--- a/.github/workflows/devops-boards.yaml
+++ b/.github/workflows/devops-boards.yaml
@@ -17,8 +17,10 @@ permissions:
   issues: write
 
 jobs:
-  alert:
+  ado:
     runs-on: ubuntu-latest
+    environment:
+      name: issues
     steps:
       # Auth using Azure Service Principals was added as a part of v2.3
       # reference: https://github.com/danhellem/github-actions-issue-to-work-item/pull/143

--- a/.github/workflows/devops-boards.yaml
+++ b/.github/workflows/devops-boards.yaml
@@ -4,8 +4,6 @@ on:
   issues:
     types:
       [opened, edited, deleted, closed, reopened, labeled, unlabeled, assigned]
-  issue_comment:
-    types: [created, edited, deleted]
 
 concurrency:
   group: issue-${{ github.event.issue.number }}
@@ -18,7 +16,6 @@ permissions:
 
 jobs:
   ado:
-    if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     environment:
       name: issues

--- a/.github/workflows/devops-boards.yaml
+++ b/.github/workflows/devops-boards.yaml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   ado:
+    if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     environment:
       name: issues

--- a/.github/workflows/devops-boards.yaml
+++ b/.github/workflows/devops-boards.yaml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   ado:
+    if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     environment:
       name: issues
@@ -35,8 +36,7 @@ jobs:
         run:
           # The resource ID for Azure DevOps is always 499b84ac-1321-427f-aa17-267ca6975798
           # https://learn.microsoft.com/azure/devops/integrate/get-started/authentication/service-principal-managed-identity
-          accessToken=$(az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query "accessToken" --output tsv)
-          echo "ADO_TOKEN=$accessToken" >> $GITHUB_ENV
+          echo "ADO_TOKEN=$(az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query "accessToken" --output tsv)" >> $GITHUB_ENV
       - name: Sync issue to Azure DevOps
         uses: danhellem/github-actions-issue-to-work-item@v2.3
         env:

--- a/.github/workflows/devops-boards.yaml
+++ b/.github/workflows/devops-boards.yaml
@@ -4,10 +4,17 @@ on:
   issues:
     types:
       [opened, edited, deleted, closed, reopened, labeled, unlabeled, assigned]
+  issue_comment:
+    types: [created, edited, deleted]
 
 concurrency:
   group: issue-${{ github.event.issue.number }}
   cancel-in-progress: false
+
+# Extra permissions needed to login with Entra ID service principal via federated identity
+permissions:
+  id-token: write
+  issues: write
 
 jobs:
   alert:

--- a/.github/workflows/devops-boards.yaml
+++ b/.github/workflows/devops-boards.yaml
@@ -20,8 +20,6 @@ jobs:
   ado:
     if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
-    environment:
-      name: issues
     steps:
       # Auth using Azure Service Principals was added as a part of v2.3
       # reference: https://github.com/danhellem/github-actions-issue-to-work-item/pull/143


### PR DESCRIPTION
exclude issue comments as these seem to catch PR comments and treat them as Issues in the sync workflow. This is aligned with current workflows in other repos today: 
- https://github.com/radius-project/radius/blob/main/.github/workflows/devops-boards.yaml