### PR TITLE
Add support for local-debuging instance of Radius

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,6 +43,12 @@ jobs:
       - name: Format
         if: ${{ env.CI_LINT == 'true' }}
         run: yarn run format:check
+      - name: Link Configuration
+        if: ${{ env.CI_LINT == 'true' }}
+        run: |
+          yarn backstage-cli config:check --config app-config.dashboard.yaml
+          yarn backstage-cli config:check --config app-config.dev.yaml
+          yarn backstage-cli config:check --config app-config.local.yaml
       - name: Build TypeScript
         run: yarn run tsc
       - name: Build

--- a/app-config.dashboard.yaml
+++ b/app-config.dashboard.yaml
@@ -32,3 +32,8 @@ catalog:
   # See https://backstage.io/docs/features/software-catalog/#adding-components-to-the-catalog for more details
   # on how to get entities into the catalog.
   locations: []
+
+radius:
+  # Find Radius inside the Kubernetes cluster.
+  connection:
+    kind: kubernetes

--- a/app-config.local.yaml
+++ b/app-config.local.yaml
@@ -20,9 +20,26 @@ kubernetes:
   clusterLocatorMethods:
     - type: localKubectlProxy
 
+proxy:
+  endpoints:
+    # Proxy to a local Radius instance.
+    '/radius': http://localhost:9000
+
+radius:
+  # Find Radius inside the Kubernetes cluster by default.
+  # connection:
+  #   kind: kubernetes
+  #   url: ''
+  # Optionally uncomment the following block to use a local debug instance of Radius.
+  connection:
+    kind: direct
+
+
 backend:
   # Allow the backend to make requests to the local Kubernetes cluster.
   reading:
     allow:
       - host: localhost:8001
       - host: 127.0.0.1:8001
+      - host: localhost:9000
+      - host: 127.0.0.1:9000

--- a/plugins/plugin-radius/config.d.ts
+++ b/plugins/plugin-radius/config.d.ts
@@ -1,0 +1,17 @@
+export interface Config {
+  /**
+   * Radius plugin configuration
+   */
+  radius: {
+    /**
+     * Configuration for the connection to Radius.
+     */
+    connection: {
+      /**
+       * Kind of connection to Radius. Use `direct` for direct connection to Radius server, or `kubernetes` for connection to Radius server running in Kubernetes.
+       * @visibility frontend
+       */
+      kind: "direct" | "kubernetes";
+    };
+  };
+}

--- a/plugins/plugin-radius/package.json
+++ b/plugins/plugin-radius/package.json
@@ -56,6 +56,8 @@
     "msw": "^1.0.0"
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
 }

--- a/plugins/plugin-radius/src/api/api.test.ts
+++ b/plugins/plugin-radius/src/api/api.test.ts
@@ -1,131 +1,152 @@
-import { makePath, makePathForId, RadiusApiImpl } from './api';
+import { Connection, KubernetesConnection, RadiusApiImpl } from "./api";
 
-describe('makePath', () => {
-  it('makes path for scopes', () => {
-    const path = makePath({ scopes: [{ type: 'radius', value: 'local' }] });
-    expect(path).toEqual(makePathForId('/planes/radius/local'));
-  });
-  it('makes path for multiple scopes', () => {
-    const path = makePath({
-      scopes: [
-        { type: 'radius', value: 'local' },
-        {
-          type: 'resourceGroups',
-          value: 'test-group',
+describe("KubernetesConnection", () => {
+  it("selectCluster returns first cluster", async () => {
+    const connection = new KubernetesConnection({
+        getClusters: async () => [
+          { name: "test-cluster1", authProvider: "test" },
+          {
+            name: "test-cluster2",
+            authProvider: "test",
+          },
+        ],
+        proxy: async () => {
+          throw new Error("not implemented");
         },
-      ],
-    });
-    expect(path).toEqual(
-      makePathForId('/planes/radius/local/resourceGroups/test-group'),
-    );
+      });
+    expect(await connection.selectCluster()).toEqual("test-cluster1");
   });
-  it('makes path for scope list', () => {
-    const path = makePath({
-      scopes: [
-        { type: 'radius', value: 'local' },
-        {
-          type: 'resourceGroups',
-        },
-      ],
-    });
-    expect(path).toEqual(makePathForId('/planes/radius/local/resourceGroups'));
-  });
-  it('makes path for scope action', () => {
-    const path = makePath({
-      scopes: [{ type: 'radius', value: 'local' }],
-      action: 'action',
-    });
-    expect(path).toEqual(makePathForId('/planes/radius/local/action'));
-  });
-  it('makes path for resource type without name', () => {
-    const path = makePath({
-      scopes: [{ type: 'radius', value: 'local' }],
-      type: 'Applications.Core/applications',
-    });
-    expect(path).toEqual(
-      makePathForId(
-        '/planes/radius/local/providers/Applications.Core/applications',
-      ),
-    );
-  });
-  it('makes path for resource type with name', () => {
-    const path = makePath({
-      scopes: [{ type: 'radius', value: 'local' }],
-      type: 'Applications.Core/applications',
-      name: 'test-app',
-    });
-    expect(path).toEqual(
-      makePathForId(
-        '/planes/radius/local/providers/Applications.Core/applications/test-app',
-      ),
-    );
-  });
-  it('makes path for resource type with name and action', () => {
-    const path = makePath({
-      scopes: [{ type: 'radius', value: 'local' }],
-      type: 'Applications.Core/applications',
-      name: 'test-app',
-      action: 'restart',
-    });
-    expect(path).toEqual(
-      makePathForId(
-        '/planes/radius/local/providers/Applications.Core/applications/test-app/restart',
-      ),
-    );
-  });
-});
+})
 
-describe('RadiusApi', () => {
-  it('selectCluster returns first cluster', async () => {
-    const api = new RadiusApiImpl({
-      getClusters: async () => [
-        { name: 'test-cluster1', authProvider: 'test' },
-        {
-          name: 'test-cluster2',
-          authProvider: 'test',
+describe("RadiusApi", () => {
+  const makeApi = (
+    mocks?: {
+      connection?: Connection;
+    },
+  ) => {
+    return new RadiusApiImpl(
+      mocks?.connection ?? {
+        send() {
+          throw new Error(`Not implemented`);
         },
-      ],
-      proxy: async () => {
-        throw new Error('not implemented');
       },
+    );
+  };
+
+  describe("makePath", () => {
+    const api = makeApi();
+
+    it("makes path for scopes", () => {
+      const path = api.makePath({
+        scopes: [{ type: "radius", value: "local" }],
+      });
+      expect(path).toEqual(api.makePathForId("/planes/radius/local"));
     });
-    // eslint-disable-next-line dot-notation
-    expect(await api['selectCluster']()).toEqual('test-cluster1');
+    it("makes path for multiple scopes", () => {
+      const path = api.makePath({
+        scopes: [
+          { type: "radius", value: "local" },
+          {
+            type: "resourceGroups",
+            value: "test-group",
+          },
+        ],
+      });
+      expect(path).toEqual(
+        api.makePathForId("/planes/radius/local/resourceGroups/test-group"),
+      );
+    });
+    it("makes path for scope list", () => {
+      const path = api.makePath({
+        scopes: [
+          { type: "radius", value: "local" },
+          {
+            type: "resourceGroups",
+          },
+        ],
+      });
+      expect(path).toEqual(
+        api.makePathForId("/planes/radius/local/resourceGroups"),
+      );
+    });
+    it("makes path for scope action", () => {
+      const path = api.makePath({
+        scopes: [{ type: "radius", value: "local" }],
+        action: "action",
+      });
+      expect(path).toEqual(api.makePathForId("/planes/radius/local/action"));
+    });
+    it("makes path for resource type without name", () => {
+      const path = api.makePath({
+        scopes: [{ type: "radius", value: "local" }],
+        type: "Applications.Core/applications",
+      });
+      expect(path).toEqual(
+        api.makePathForId(
+          "/planes/radius/local/providers/Applications.Core/applications",
+        ),
+      );
+    });
+    it("makes path for resource type with name", () => {
+      const path = api.makePath({
+        scopes: [{ type: "radius", value: "local" }],
+        type: "Applications.Core/applications",
+        name: "test-app",
+      });
+      expect(path).toEqual(
+        api.makePathForId(
+          "/planes/radius/local/providers/Applications.Core/applications/test-app",
+        ),
+      );
+    });
+    it("makes path for resource type with name and action", () => {
+      const path = api.makePath({
+        scopes: [{ type: "radius", value: "local" }],
+        type: "Applications.Core/applications",
+        name: "test-app",
+        action: "restart",
+      });
+      expect(path).toEqual(
+        api.makePathForId(
+          "/planes/radius/local/providers/Applications.Core/applications/test-app/restart",
+        ),
+      );
+    });
   });
-  it('makeRequest handles errors', async () => {
-    const api = new RadiusApiImpl({
-      getClusters: async () => {
-        throw new Error('not implemented');
+
+  it("makeRequest handles errors", async () => {
+    const api = makeApi({
+      connection: {
+        send: async () =>
+          Promise.resolve(new Response("test", { status: 404 })),
       },
-      proxy: async () => Promise.resolve(new Response('test', { status: 404 })),
     });
     // eslint-disable-next-line dot-notation
-    await expect(api['makeRequest']('cluster', 'path')).rejects.toThrow(
-      'Request failed: 404:\n\ntest',
+    await expect(api["makeRequest"]("path")).rejects.toThrow(
+      "Request failed: 404:\n\ntest",
     );
   });
-  it('makeRequest expects JSON', async () => {
-    const api = new RadiusApiImpl({
-      getClusters: async () => {
-        throw new Error('not implemented');
+  it("makeRequest expects JSON", async () => {
+    const api = makeApi({
+      connection: {
+        send: async () => Promise.resolve(new Response("test")),
       },
-      proxy: async () => Promise.resolve(new Response('test')),
     });
     // eslint-disable-next-line dot-notation
-    await expect(api['makeRequest']('cluster', 'path')).rejects.toThrow(
-      'invalid json response body at  reason: Unexpected token \'e\', "test" is not valid JSON',
+    await expect(api["makeRequest"]("path")).rejects.toThrow(
+      "Request was not json: 200:\n\ntest",
     );
   });
-  it('makeRequest parses JSON', async () => {
-    const api = new RadiusApiImpl({
-      getClusters: async () => {
-        throw new Error('not implemented');
+  it("makeRequest parses JSON", async () => {
+    const api = makeApi({
+      connection: {
+        send: async () =>
+          Promise.resolve(new Response('{ "message": "test" }')),
       },
-      proxy: async () => Promise.resolve(new Response('{ "message": "test" }')),
     });
     // eslint-disable-next-line dot-notation
-    await expect(api['makeRequest']('cluster', 'path')).resolves.toEqual({
-      message: 'test',
+    await expect(api["makeRequest"]("path")).resolves.toEqual({
+      message: "test",
     });
   });
 });

--- a/plugins/plugin-radius/src/api/api.ts
+++ b/plugins/plugin-radius/src/api/api.ts
@@ -1,10 +1,53 @@
-import { KubernetesApi } from '@backstage/plugin-kubernetes';
+import { KubernetesApi } from "@backstage/plugin-kubernetes";
 import {
   ApplicationProperties,
   EnvironmentProperties,
   Resource,
   ResourceList,
-} from '../resources';
+} from "../resources";
+
+export interface Connection {
+  send(path: string, init?: RequestInit): Promise<Response>;
+}
+
+export class DirectConnection implements Connection {
+  constructor(private readonly baseUrl: string) {
+  }
+
+  send(path: string, init?: RequestInit): Promise<Response> {
+    const combined = `${this.baseUrl}/${path}`;
+    return fetch(combined, init);
+  }
+}
+
+const pathPrefix = "/apis/api.ucp.dev/v1alpha3";
+
+export class KubernetesConnection implements Connection {
+  constructor(
+    private readonly kubernetesApi: Pick<
+      KubernetesApi,
+      "getClusters" | "proxy"
+    >,
+  ) {
+  }
+  async send(path: string, init?: RequestInit): Promise<Response> {
+    const clusterName = await this.selectCluster();
+    return this.kubernetesApi.proxy({
+      clusterName: clusterName,
+      path: `${pathPrefix}/${path}`,
+      init: init,
+    });
+  }
+
+  async selectCluster(): Promise<string> {
+    const clusters = await this.kubernetesApi.getClusters();
+    for (const cluster of clusters) {
+      return cluster.name;
+    }
+
+    throw new Error("No kubernetes clusters found");
+  }
+}
 
 export interface RadiusApi {
   getResourceById<T = { [key: string]: unknown }>(opts: {
@@ -23,70 +66,61 @@ export interface RadiusApi {
   }): Promise<ResourceList<T>>;
 }
 
-const pathPrefix = '/apis/api.ucp.dev/v1alpha3';
-const apiVersion = '?api-version=2023-10-01-preview';
-
-export const makePathForId = (id: string) => {
-  return `${pathPrefix}${id}${apiVersion}`;
-};
-
-export const makePath = ({
-  scopes,
-  type,
-  name,
-  action,
-}: {
-  scopes: { type: string; value?: string }[];
-  type?: string;
-  name?: string;
-  action?: string;
-}) => {
-  const scopePart = scopes
-    .map(s => {
-      if (s.value) {
-        return `${s.type}/${s.value}`;
-      }
-
-      return s.type;
-    })
-    .join('/');
-  const typePart = type ? `/providers/${type}` : '';
-  const namePart = name ? `/${name}` : '';
-  const actionPart = action ? `/${action}` : '';
-  const id = `/planes/${scopePart}${typePart}${namePart}${actionPart}`;
-  return makePathForId(id);
-};
+const apiVersion = "?api-version=2023-10-01-preview";
 
 export class RadiusApiImpl implements RadiusApi {
-  constructor(
-    private readonly kubernetesApi: Pick<
-      KubernetesApi,
-      'getClusters' | 'proxy'
-    >,
-  ) {}
+  constructor(private readonly connection: Connection) {}
+
+  makePathForId(id: string): string {
+    return `${id}${apiVersion}`;
+  }
+
+  makePath({
+    scopes,
+    type,
+    name,
+    action,
+  }: {
+    scopes: { type: string; value?: string }[];
+    type?: string;
+    name?: string;
+    action?: string;
+  }): string {
+    const scopePart = scopes
+      .map((s) => {
+        if (s.value) {
+          return `${s.type}/${s.value}`;
+        }
+
+        return s.type;
+      })
+      .join("/");
+    const typePart = type ? `/providers/${type}` : "";
+    const namePart = name ? `/${name}` : "";
+    const actionPart = action ? `/${action}` : "";
+    const id = `/planes/${scopePart}${typePart}${namePart}${actionPart}`;
+    return this.makePathForId(id);
+  }
 
   async listResources<T = { [key: string]: unknown }>(
     opts?: { resourceType?: string; resourceGroup?: string } | undefined,
   ): Promise<ResourceList<T>> {
-    const cluster = await this.selectCluster();
-
     // Fast path for listing resources of a specific type.
     if (opts?.resourceType) {
-      const path = makePath({
+      const path = this.makePath({
         scopes: this.makeScopes(opts),
         type: opts.resourceType,
       });
-      return this.makeRequest<ResourceList<T>>(cluster, path);
+      return this.makeRequest<ResourceList<T>>(path);
     }
 
     // no way to list resources in all groups yet :-/. Let's do the O(n) thing for now.
     const groups = await this.makeRequest<ResourceList<Record<string, never>>>(
-      cluster,
-      makePath({
+      this.makePath({
         scopes: [
-          { type: 'radius', value: 'local' },
+          { type: "radius", value: "local" },
           {
-            type: 'resourceGroups',
+            type: "resourceGroups",
           },
         ],
       }),
@@ -95,24 +129,24 @@ export class RadiusApiImpl implements RadiusApi {
     for (const group of groups.value) {
       // Unfortunately we don't include all of the relevant properties in tracked resources.
       // This is inefficient, but we'll have to do it for now.
-      const path = makePath({
+      const path = this.makePath({
         scopes: [
-          { type: 'radius', value: 'local' },
+          { type: "radius", value: "local" },
           {
-            type: 'resourceGroups',
+            type: "resourceGroups",
             value: group.name,
           },
         ],
-        action: 'resources',
+        action: "resources",
       });
       const groupResources = await this.makeRequest<
         ResourceList<Record<string, never>>
-      >(cluster, path);
+      >(path);
       if (groupResources.value) {
         for (const resource of groupResources.value) {
           // Deployments show up in tracked resources, but the RP may not hold onto them.
           // There's limited value here so skip them for now.
-          if (resource.type === 'Microsoft.Resources/deployments') {
+          if (resource.type === "Microsoft.Resources/deployments") {
             continue;
           }
           resources.push(await this.getResourceById<T>({ id: resource.id }));
@@ -125,75 +159,60 @@ export class RadiusApiImpl implements RadiusApi {
   async getResourceById<T = { [key: string]: unknown }>(opts: {
     id: string;
   }): Promise<Resource<T>> {
-    const cluster = await this.selectCluster();
-
-    const path = makePathForId(opts.id);
-    const resource = await this.makeRequest<Resource<T>>(cluster, path);
+    const path = this.makePathForId(opts.id);
+    const resource = await this.makeRequest<Resource<T>>(path);
     return await this.fixupResource(resource);
   }
 
   async listApplications<T = ApplicationProperties>(opts?: {
     resourceGroup?: string;
   }): Promise<ResourceList<T>> {
-    const cluster = await this.selectCluster();
-
-    const path = makePath({
+    const path = this.makePath({
       scopes: this.makeScopes(opts),
-      type: 'Applications.Core/applications',
+      type: "Applications.Core/applications",
     });
-    return this.makeRequest<ResourceList<T>>(cluster, path);
+    return this.makeRequest<ResourceList<T>>(path);
   }
 
   async listEnvironments<T = EnvironmentProperties>(opts?: {
     resourceGroup?: string;
   }): Promise<ResourceList<T>> {
-    const cluster = await this.selectCluster();
-
-    const path = makePath({
+    const path = this.makePath({
       scopes: this.makeScopes(opts),
-      type: 'Applications.Core/environments',
+      type: "Applications.Core/environments",
     });
-    return this.makeRequest<ResourceList<T>>(cluster, path);
-  }
-
-  private async selectCluster(): Promise<string> {
-    const clusters = await this.kubernetesApi.getClusters();
-    for (const cluster of clusters) {
-      return cluster.name;
-    }
-
-    throw new Error('No kubernetes clusters found');
+    return this.makeRequest<ResourceList<T>>(path);
   }
 
   private makeScopes(opts?: {
     resourceGroup?: string;
   }): { type: string; value?: string }[] {
-    const scopes = [{ type: 'radius', value: 'local' }];
+    const scopes = [{ type: "radius", value: "local" }];
     if (opts?.resourceGroup) {
-      scopes.push({ type: 'resourceGroups', value: opts.resourceGroup });
+      scopes.push({ type: "resourceGroups", value: opts.resourceGroup });
     }
     return scopes;
   }
 
-  private async makeRequest<T>(cluster: string, path: string): Promise<T> {
-    const response = await this.kubernetesApi.proxy({
-      clusterName: cluster,
-      path: path,
-      init: {
-        referrerPolicy: 'no-referrer', // See https://github.com/radius-project/radius/issues/6983
-        mode: 'cors',
-        cache: 'no-cache',
-        method: 'GET',
-      },
+  private async makeRequest<T>(path: string): Promise<T> {
+    const response = await this.connection.send(path, {
+      referrerPolicy: "no-referrer", // See https://github.com/radius-project/radius/issues/6983
+      mode: "cors",
+      cache: "no-cache",
+      method: "GET",
     });
 
+    const text = await response.text();
     if (!response.ok) {
-      const text = await response.text();
       throw new Error(`Request failed: ${response.status}:\n\n${text}`);
     }
 
-    const data = (await response.json()) as T;
-    return data;
+    try {
+      const data = JSON.parse(text) as T;
+      return data;
+    } catch (error) {
+      throw new Error(`Request was not json: ${response.status}:\n\n${text}`);
+    }
   }
 
   private async fixupResource<T>(resource: Resource<T>): Promise<Resource<T>> {


### PR DESCRIPTION
# Description

This existing logic in the dashboard only knows how to connect to Radius when it's running inside a Kubernetes cluster. This commit makes the connection logic configurable, and adds example configuration that works with a locally installed build of Radius.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius Dashboard (issue link optional).
