### PR TITLE
Dev container configuration improvements and CI workflow

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,5 +1,10 @@
 {
   "features": {
+    "ghcr.io/devcontainers-extra/features/corepack:1": {
+      "version": "1.0.2",
+      "resolved": "ghcr.io/devcontainers-extra/features/corepack@sha256:5142e3f736841bf4cd1b9d8e6a2e51885cab510d5f014eac10be9b0627a9bf97",
+      "integrity": "sha256:5142e3f736841bf4cd1b9d8e6a2e51885cab510d5f014eac10be9b0627a9bf97"
+    },
     "ghcr.io/devcontainers/features/common-utils:2.5.7": {
       "version": "2.5.7",
       "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:dbf431d6b42d55cde50fa1df75c7f7c3999a90cde6d73f7a7071174b3c3d0cc4",
@@ -19,6 +24,19 @@
       "version": "1.7.1",
       "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
       "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    },
+    "ghcr.io/dhoeric/features/oras:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/dhoeric/features/oras@sha256:d08787b42a60d49b001260e00967fd2206326f552e5f7f09ce2535de2f351d8d",
+      "integrity": "sha256:d08787b42a60d49b001260e00967fd2206326f552e5f7f09ce2535de2f351d8d"
+    },
+    "ghcr.io/radius-project/devcontainer-features/radcli:0": {
+      "version": "0.1.0",
+      "resolved": "ghcr.io/radius-project/devcontainer-features/radcli@sha256:3d43cbe806dfb608f3aacee83f2a6e60e21fac3275748aa9fdb1c4fd2595b5fd",
+      "integrity": "sha256:3d43cbe806dfb608f3aacee83f2a6e60e21fac3275748aa9fdb1c4fd2595b5fd",
+      "dependsOn": [
+        "ghcr.io/dhoeric/features/oras:1"
+      ]
     },
     "ghcr.io/rio/features/k3d:1.1.0": {
       "version": "1.1.0",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,7 @@
     "ghcr.io/devcontainers/features/node:1.7.1": {
       "installYarnUsingApt": false
     },
+    "ghcr.io/devcontainers-extra/features/corepack:1": {},
     "ghcr.io/devcontainers/features/kubectl-helm-minikube:1.3.1": {
       "version": "latest",
       "helm": "latest",
@@ -21,15 +22,17 @@
     "ghcr.io/devcontainers/features/docker-in-docker:2.16.1": {
       "version": "latest",
       "moby": true
-    }
+    },
+    "ghcr.io/radius-project/devcontainer-features/radcli:0": {}
   },
-
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  "forwardPorts": [3000, 7007, 8001],
-
+  "forwardPorts": [
+    3000,
+    7007,
+    8001
+  ],
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": "./.devcontainer/postcreate.sh",
-
   // Configure tool-specific properties.
   "customizations": {
     "vscode": {

--- a/.devcontainer/postcreate.sh
+++ b/.devcontainer/postcreate.sh
@@ -3,11 +3,8 @@
 set -eu
 
 # Install the current version of Radius
-wget -q "https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.sh" -O - | /bin/bash
+# wget -q "https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.sh" -O - | /bin/bash
 
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0 # Disable corepack download prompt (silent option)
-# Install yarn
-sudo corepack enable
-corepack prepare yarn@4.13.0 --activate
 yarn install
 yarn exec playwright install chrome

--- a/.devcontainer/postcreate.sh
+++ b/.devcontainer/postcreate.sh
@@ -2,9 +2,6 @@
 
 set -eu
 
-# Install the current version of Radius
-# wget -q "https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.sh" -O - | /bin/bash
-
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0 # Disable corepack download prompt (silent option)
 yarn install
 yarn exec playwright install chrome

--- a/.github/workflows/devcontainer.yaml
+++ b/.github/workflows/devcontainer.yaml
@@ -32,6 +32,6 @@ jobs:
           persist-credentials: false
 
       - name: Build Dev Container
-        uses: devcontainers/ci@1b8fb16e4e8d242059a66a557c8bf29a247ef751 # v0.3
+        uses: devcontainers/ci@8bf61b26e9c3a98f69cb6ce2f88d24ff59b785c6 # v0.3
         with:
           runCmd: node --version && yarn --version && kubectl version --client && rad version

--- a/.github/workflows/devcontainer.yaml
+++ b/.github/workflows/devcontainer.yaml
@@ -8,11 +8,13 @@ on:
       - main
     paths:
       - ".devcontainer/**"
+      - ".github/workflows/devcontainer.yaml"
   pull_request:
     branches:
       - main
     paths:
       - ".devcontainer/**"
+      - ".github/workflows/devcontainer.yaml"
 
 permissions: {}
 
@@ -32,4 +34,4 @@ jobs:
       - name: Build Dev Container
         uses: devcontainers/ci@1b8fb16e4e8d242059a66a557c8bf29a247ef751 # v0.3
         with:
-          runCmd: echo "Dev container build successful"
+          runCmd: node --version && yarn --version && kubectl version --client && rad version

--- a/.github/workflows/devcontainer.yaml
+++ b/.github/workflows/devcontainer.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://www.schemastore.org/github-workflow.json
+---
+name: Dev Container Build
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".devcontainer/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".devcontainer/**"
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build Dev Container
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Build Dev Container
+        uses: devcontainers/ci@1b8fb16e4e8d242059a66a557c8bf29a247ef751 # v0.3
+        with:
+          runCmd: echo "Dev container build successful"

--- a/docs/contributing/contributing-code/contributing-code-building/README.md
+++ b/docs/contributing/contributing-code/contributing-code-building/README.md
@@ -14,7 +14,7 @@ For development, we recommend VS Code. This repo is configured with recommended 
 The most common problem with building and developing in the repo is having the wrong version of Node.JS. Check your version with:
 
 ```bash
-node version
+node --version
 ```
 
 Check your yarn version with:


### PR DESCRIPTION
# Description

The dev container corepack installation was broken after the recent update to a current backstage version. 

**Changes:**
- Added `corepack` dev container feature to handle yarn setup at image build time
- Added `radcli` dev container feature to provide Radius CLI out of the box
- Removed manual corepack/yarn setup from `postcreate.sh` (now handled by features)
- Added new GitHub Actions workflow (`.github/workflows/devcontainer.yaml`) to test dev container builds on PRs and pushes to main
- Fixed `node version` → `node --version` typo in build documentation

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and does not change the functionality of Radius Dashboard (issue link optional).

## Screenshots

N/A - infrastructure/CI changes only