### PR TITLE
ci: run e2e tests against the built container image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -132,8 +132,14 @@ jobs:
           docker pull localhost:5000/dashboard:test
 
       - name: Run dashboard container
+        # NODE_ENV=development keeps the Backstage guest auth provider
+        # enabled (it is silently disabled in production mode in
+        # @backstage/plugin-auth-backend >= 0.26). Mirrors the workaround
+        # the Helm chart applies via .Values.dashboard.nodeEnv. See
+        # https://github.com/radius-project/radius/pull/11520.
         run: |
           docker run -d --name dashboard-e2e \
+            -e NODE_ENV=development \
             -p 7007:7007 \
             localhost:5000/dashboard:test
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,17 +6,19 @@ on:
   push:
     branches:
       - main
+      - 'ci/**'
     tags:
       - v*
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 permissions: {}
 
 env:
-  CI_LINT: ${{ github.event_name == 'pull_request' }}
-  CI_TEST: ${{ github.event_name == 'pull_request' }}
+  CI_LINT: ${{ github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/ci/') || github.event_name == 'workflow_dispatch' }}
+  CI_TEST: ${{ github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/ci/') || github.event_name == 'workflow_dispatch' }}
   CI_PUBLISH_RELEASE: ${{ github.repository == 'radius-project/dashboard' && startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push' }}
   CI_PUBLISH_LATEST: ${{ github.repository == 'radius-project/dashboard' && github.ref == 'refs/heads/main' && github.event_name == 'push' }}
 
@@ -69,17 +71,20 @@ jobs:
         if: ${{ env.CI_TEST == 'true' }}
         run: yarn run test:all
 
-      - name: Run E2E Tests
-        if: ${{ env.CI_TEST == 'true' }}
-        run: yarn run test:e2e
-
   build-and-publish-container:
     name: Build and Publish Container
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions:
       contents: read
       packages: write
+    services:
+      # Local OCI registry used to validate push/pull and to source the
+      # image used for the container-based E2E test below.
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -114,6 +119,55 @@ jobs:
         uses: ./.github/actions/analyze-image
         with:
           image: ghcr.io/radius-project/dashboard:latest
+
+      - name: Push image to local test registry
+        run: |
+          docker tag ghcr.io/radius-project/dashboard:latest localhost:5000/dashboard:test
+          docker push localhost:5000/dashboard:test
+
+      - name: Pull image from local test registry
+        run: |
+          # Remove the local copy to ensure we actually pull from the registry.
+          docker rmi localhost:5000/dashboard:test
+          docker pull localhost:5000/dashboard:test
+
+      - name: Run dashboard container
+        run: |
+          docker run -d --name dashboard-e2e \
+            -p 7007:7007 \
+            localhost:5000/dashboard:test
+
+      - name: Wait for dashboard to be ready
+        run: |
+          for i in {1..60}; do
+            if curl -sf http://localhost:7007/ > /dev/null; then
+              echo "Dashboard is ready"
+              exit 0
+            fi
+            echo "Waiting for dashboard... ($i/60)"
+            sleep 2
+          done
+          echo "Dashboard did not become ready in time"
+          docker logs dashboard-e2e || true
+          exit 1
+
+      - name: Install Playwright browsers
+        if: ${{ env.CI_TEST == 'true' }}
+        run: yarn exec playwright install --with-deps chromium
+
+      - name: Run E2E Tests against container
+        if: ${{ env.CI_TEST == 'true' }}
+        env:
+          PLAYWRIGHT_URL: http://localhost:7007
+        run: yarn run test:e2e
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker logs dashboard-e2e || true
+
+      - name: Stop dashboard container
+        if: always()
+        run: docker rm -f dashboard-e2e || true
 
       - name: Login to ghcr.io
         if: ${{ env.CI_PUBLISH_LATEST == 'true' || env.CI_PUBLISH_RELEASE == 'true' }}

--- a/packages/app/e2e-tests/app.test.ts
+++ b/packages/app/e2e-tests/app.test.ts
@@ -19,11 +19,17 @@ import { test, expect } from '@playwright/test';
 test('App should render the home page', async ({ page }) => {
   await page.goto('/');
 
-  // Accept any dialog that appears during the guest sign-in flow.
-  // Backstage may show a confirm dialog: "Failed to sign in as a guest
-  // using the auth backend. Do you want to fallback to the legacy guest token?"
-  // Accepting it allows the test to proceed with the legacy guest token.
-  page.on('dialog', dialog => dialog.accept());
+  // Fail fast if Backstage shows the legacy guest-token fallback dialog.
+  // That dialog only appears when the auth-backend guest provider is
+  // disabled (e.g. when NODE_ENV=production silently disables guest auth
+  // in @backstage/plugin-auth-backend >= 0.26 — see
+  // https://github.com/radius-project/radius/pull/11520). We want CI to
+  // surface that regression instead of routing around it.
+  page.on('dialog', async dialog => {
+    throw new Error(
+      `Unexpected dialog from Backstage auth flow: ${dialog.message()}`,
+    );
+  });
 
   // Click the Enter button on the sign-in page to complete guest authentication.
   const enterButton = page.getByRole('button', { name: 'Enter' });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -47,7 +47,9 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
 
   reporter: [
+    ['list'],
     ['html', { open: 'never', outputFolder: './logs/e2e-test-report' }],
+    ...(process.env.CI ? [['github'] as [string]] : []),
   ],
 
   use: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,6 +20,10 @@ import { generateProjects } from '@backstage/e2e-test-utils/playwright';
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
+// When PLAYWRIGHT_URL is set (e.g. running e2e against a pre-started container),
+// skip starting the local dev server.
+const useExternalServer = !!process.env.PLAYWRIGHT_URL;
+
 export default defineConfig({
   timeout: 60_000,
 
@@ -27,13 +31,16 @@ export default defineConfig({
     timeout: 5_000,
   },
 
-  // Run your local dev server before starting the tests
-  webServer: {
-    command: 'yarn start',
-    port: 3000,
-    reuseExistingServer: true,
-    timeout: 60_000,
-  },
+  // Run your local dev server before starting the tests, unless an external
+  // server URL is provided via PLAYWRIGHT_URL.
+  webServer: useExternalServer
+    ? undefined
+    : {
+        command: 'yarn start',
+        port: 3000,
+        reuseExistingServer: true,
+        timeout: 60_000,
+      },
 
   forbidOnly: !!process.env.CI,
 


### PR DESCRIPTION
Push the built dashboard image to a localhost:5000 registry service, pull it back, run it as a container, and run Playwright against http://localhost:7007 instead of 'yarn start'.

Set NODE_ENV=development on the container so the Backstage guest auth provider stays enabled (radius-project/radius#11520).

playwright.config.ts: skip the dev-server webServer block when PLAYWRIGHT_URL is set.

# Description

_Please explain the changes you've made._

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius Dashboard and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius Dashboard and has an approved issue (issue link required).
- This pull request adds or changes features of Radius Dashboard and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius Dashboard (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Screenshots

<!--

Please attach screenshots of UI resulting from the changes.

-->