### PR TITLE
Add Dependabot cooldown to all updates entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       all:
         patterns:
@@ -17,6 +19,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       all:
         patterns:
@@ -26,6 +30,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       all:
         patterns:


### PR DESCRIPTION
# Description

Adds a `cooldown` block (`default-days: 7`) to every active `updates:` entry in `.github/dependabot.yml` (github-actions, npm, and devcontainers ecosystems).

The cooldown setting delays Dependabot from opening update PRs until 7 days after a dependency release. This reduces PR churn from rapid back-to-back releases and gives newly published versions time to stabilize before we adopt them.

This change is scoped to this repository and is part of an org-wide rollout following [radius-project/radius #12141](https://github.com/radius-project/radius/pull/12141) ("Add Dependabot cooldown to all updates entries").

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius Dashboard (issue link optional).

This is a CI/maintenance, no-functional-change task affecting only Dependabot configuration.