### PR TITLE
Show Radius.Core resource types by default on resource-types page

### DIFF
--- a/plugins/plugin-radius/src/components/resourcetypes/ResourceTypesTable.test.tsx
+++ b/plugins/plugin-radius/src/components/resourcetypes/ResourceTypesTable.test.tsx
@@ -193,6 +193,18 @@ describe('ResourceTypesTable', () => {
               },
             },
             {
+              id: '/planes/radius/local/providers/System.Resources/resourceproviders/Radius.Core',
+              name: 'Radius.Core',
+              type: 'System.Resources/resourceproviders',
+              systemData: {},
+              properties: {
+                namespace: 'Radius.Core',
+                type: 'environments',
+                apiVersion: '2023-10-01-preview',
+                apiVersions: ['2023-10-01-preview'],
+              },
+            },
+            {
               id: '/planes/radius/local/providers/System.Resources/resourceproviders/Applications.Core',
               name: 'Applications.Core',
               type: 'System.Resources/resourceproviders',
@@ -200,6 +212,18 @@ describe('ResourceTypesTable', () => {
               properties: {
                 namespace: 'Applications.Core',
                 type: 'containers',
+                apiVersion: '2021-04-01',
+                apiVersions: ['2021-04-01'],
+              },
+            },
+            {
+              id: '/planes/radius/local/providers/System.Resources/resourceproviders/Microsoft.Resources',
+              name: 'Microsoft.Resources',
+              type: 'System.Resources/resourceproviders',
+              systemData: {},
+              properties: {
+                namespace: 'Microsoft.Resources',
+                type: 'deployments',
                 apiVersion: '2021-04-01',
                 apiVersions: ['2021-04-01'],
               },
@@ -227,13 +251,18 @@ describe('ResourceTypesTable', () => {
     const table = screen.getByRole('table');
     const rows = table.querySelectorAll('tbody > tr');
 
-    // Should only show 1 row (Custom.Database), Applications.Core should be filtered
-    expect(rows).toHaveLength(1);
-    const row1 = rows[0];
+    // Should show Custom.Database and Radius.Core; Applications.* and
+    // Microsoft.* should be filtered out by default.
+    expect(rows).toHaveLength(2);
 
-    const row1Cells = row1.querySelectorAll('td');
-    expect(row1Cells[0]).toHaveTextContent('mongoDatabases');
-    expect(row1Cells[1]).toHaveTextContent('Custom.Database');
+    const namespaces = Array.from(rows).map(
+      row => row.querySelectorAll('td')[1].textContent,
+    );
+    expect(namespaces).toEqual(
+      expect.arrayContaining(['Custom.Database', 'Radius.Core']),
+    );
+    expect(namespaces).not.toContain('Applications.Core');
+    expect(namespaces).not.toContain('Microsoft.Resources');
 
     // Verify that the checkbox exists
     const checkbox = screen.getByRole('checkbox');

--- a/plugins/plugin-radius/src/components/resourcetypes/ResourceTypesTable.tsx
+++ b/plugins/plugin-radius/src/components/resourcetypes/ResourceTypesTable.tsx
@@ -40,7 +40,7 @@ export const ResourceTypesTable = (props: { title: string }) => {
 
   // Filter resource types based on checkbox state
   // Hide commonly built-in namespaces by default to reduce clutter
-  const EXCLUDED_NAMESPACES = ['Applications.', 'Microsoft.', 'Radius.Core'];
+  const EXCLUDED_NAMESPACES = ['Applications.', 'Microsoft.'];
   const allData = value?.value || [];
   const filteredData = showOtherResourceTypes
     ? allData


### PR DESCRIPTION
## Summary

Removes `Radius.Core` from the default namespace exclusion filter on the resource-types page so those types are visible by default. Only `Applications.*` and `Microsoft.*` remain hidden until "Show all resource types" is checked.

## Reason for change

`Radius.Core` resource types are user-facing and actively used, but the default filter on the resource-types page was hiding them alongside internal/system types. Users had to click "Show all resource types" to see them. The exclusion list should surface `Radius.Core` while continuing to hide `Applications.*` and `Microsoft.*`.

Fixes #326

## How to test

1. Run the dashboard locally (`kubectl proxy` + `yarn dev`) against a Radius-enabled cluster.
2. Navigate to the **Resource Types** page.
3. Confirm `Radius.Core` resource types now appear by default, while `Applications.*` and `Microsoft.*` types remain hidden until "Show all resource types" is checked.

Automated coverage:

```bash
yarn workspace @internal/plugin-radius test src/components/resourcetypes/ResourceTypesTable.test.tsx